### PR TITLE
fix:添加控件弹窗-控件元素值输入框只能一行会过来换行符的问题

### DIFF
--- a/src/components/ElementUpdate.vue
+++ b/src/components/ElementUpdate.vue
@@ -140,6 +140,8 @@ onMounted(() => {
         </template>
       </el-upload>
       <el-input
+          type="textarea"
+          autosize
           v-else
           v-model="element.eleValue"
           placeholder="请输入控件元素值"


### PR DESCRIPTION
Flutter开发的App在使用Android/iOS Driver获取控件元素时，会有换行符存在，而前端控件只能一行展示时会将换行符过滤掉，
造成无法定位到控件。