### PR TITLE
feat: 控件元素页面增加快速添加元素按钮

### DIFF
--- a/src/components/ElementUpdate.vue
+++ b/src/components/ElementUpdate.vue
@@ -5,7 +5,8 @@ import axios from "../http/axios";
 
 const props = defineProps({
   projectId: Number,
-  elementId: Number
+  elementId: Number,
+  elementObj: Object
 })
 const emit = defineEmits(['flush'])
 const element = ref({
@@ -72,6 +73,11 @@ const saveElement = () => {
 onMounted(() => {
   if (props.elementId !== 0) {
     getElementInfo(props.elementId)
+  }
+  if (props.elementObj) {
+    element.value.eleType = props.elementObj.eleType
+    element.value.eleValue = props.elementObj.eleValue
+    console.log("element:", element.value)
   }
 })
 </script>

--- a/src/components/ElementUpdate.vue
+++ b/src/components/ElementUpdate.vue
@@ -5,7 +5,8 @@ import axios from "../http/axios";
 
 const props = defineProps({
   projectId: Number,
-  elementId: Number
+  elementId: Number,
+  elementObj: Object
 })
 const emit = defineEmits(['flush'])
 const element = ref({
@@ -72,6 +73,10 @@ const saveElement = () => {
 onMounted(() => {
   if (props.elementId !== 0) {
     getElementInfo(props.elementId)
+  }
+  if (props.elementObj) {
+    element.value.eleType = props.elementObj.eleType
+    element.value.eleValue = props.elementObj.eleValue
   }
 })
 </script>

--- a/src/components/ElementUpdate.vue
+++ b/src/components/ElementUpdate.vue
@@ -5,8 +5,7 @@ import axios from "../http/axios";
 
 const props = defineProps({
   projectId: Number,
-  elementId: Number,
-  elementObj: Object
+  elementId: Number
 })
 const emit = defineEmits(['flush'])
 const element = ref({
@@ -73,11 +72,6 @@ const saveElement = () => {
 onMounted(() => {
   if (props.elementId !== 0) {
     getElementInfo(props.elementId)
-  }
-  if (props.elementObj) {
-    element.value.eleType = props.elementObj.eleType
-    element.value.eleValue = props.elementObj.eleValue
-    console.log("element:", element.value)
   }
 })
 </script>

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -416,14 +416,6 @@ const copy = (value) => {
     });
   }
 };
-const toAddElement = (eleType, eleValue) => {
-  if (project) {
-    element.value.eleType = eleType
-    element.value.eleValue = eleValue
-    dialogElement.value = true
-  }
-
-}
 const removeScreen = () => {
   screenUrls.value = [];
 };
@@ -1733,7 +1725,7 @@ onMounted(() => {
   </el-dialog>
   <el-dialog v-model="dialogElement" title="控件元素信息" width="600px">
     <element-update v-if="dialogElement" :project-id="project['id']"
-                    :element-id="0" :element-obj="element" @flush="dialogElement = false"/>
+                    :element-id="0" @flush="dialogElement = false"/>
   </el-dialog>
   <el-page-header
       @back="router.go(-1)"
@@ -2994,7 +2986,7 @@ onMounted(() => {
                                 size="small"
                                 type="primary"
                                 round
-                                @click="toAddElement('','')"
+                                @click="dialogElement = true"
                             >添加控件
                             </el-button
                             >
@@ -3035,24 +3027,23 @@ onMounted(() => {
                                   label="resource-id"
                                   style="cursor: pointer"
                                   v-if="elementDetail['resource-id']"
+                                  @click="copy(elementDetail['resource-id'])"
                               >
-                                <span @click="copy(elementDetail['resource-id'])">{{ elementDetail['resource-id'] }}</span>
-                                <a style="margin-left: 10px" @click="toAddElement('id', elementDetail['resource-id'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                <span>{{ elementDetail['resource-id'] }}</span>
                               </el-form-item>
                               <el-form-item label="xpath推荐">
                                 <el-table stripe empty-text="暂无xpath推荐语法" border :data="findBestXpath(elementDetail)"
                                           :show-header="false">
                                   <el-table-column>
                                     <template #default="scope">
-                                      <span style="cursor: pointer" @click="copy(scope.row)">{{ scope.row }}</span>
-                                      <a style="margin-left: 10px" @click="toAddElement('xpath', scope.row)"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                      <div style="cursor: pointer" @click="copy(scope.row)">{{ scope.row }}</div>
                                     </template>
                                   </el-table-column>
                                 </el-table>
                               </el-form-item>
-                              <el-form-item label="绝对路径" style="cursor: pointer">
-                                <span @click="copy(elementDetail['xpath'])">{{ elementDetail['xpath'] }}</span>
-                                <a style="margin-left: 10px" @click="toAddElement('xpath', elementDetail['xpath'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                              <el-form-item label="绝对路径" style="cursor: pointer"
+                                            @click="copy(elementDetail['xpath'])">
+                                <span>{{ elementDetail['xpath'] }}</span>
                               </el-form-item>
                               <el-form-item
                                   label="text"
@@ -3076,9 +3067,9 @@ onMounted(() => {
                               >
                                 <span>{{ elementDetail['package'] }}</span>
                               </el-form-item>
-                              <el-form-item label="中心坐标" style="cursor: pointer">
-                                <span @click="copy(computedCenter(elementDetail['bStart'], elementDetail['bEnd']))">{{ computedCenter(elementDetail['bStart'], elementDetail['bEnd']) }}</span>
-                                <a style="margin-left: 10px" @click="toAddElement('point', computedCenter(elementDetail['bStart'], elementDetail['bEnd']))"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                              <el-form-item label="中心坐标" style="cursor: pointer"
+                                            @click="copy(computedCenter(elementDetail['bStart'], elementDetail['bEnd']))">
+                                <span>{{ computedCenter(elementDetail['bStart'], elementDetail['bEnd']) }}</span>
                               </el-form-item>
                               <el-form-item label="index">
                                 <span>{{ elementDetail['index'] }}</span>

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -3036,8 +3036,15 @@ onMounted(() => {
                                   style="cursor: pointer"
                                   v-if="elementDetail['resource-id']"
                               >
-                                <span @click="copy(elementDetail['resource-id'])">{{ elementDetail['resource-id'] }}</span>
-                                <a v-if="project && project['id']" style="margin-left: 10px" @click="toAddElement('id', elementDetail['resource-id'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                <span @click="copy(elementDetail['resource-id'])">{{
+                                    elementDetail['resource-id']
+                                  }}</span>
+                                <el-icon color="green" size="16" v-if="project && project['id']"
+                                         style="vertical-align: middle;margin-left: 10px"
+                                         @click="toAddElement('id', elementDetail['resource-id'])">
+                                  <Pointer/>
+                                </el-icon>
+
                               </el-form-item>
                               <el-form-item label="xpath推荐">
                                 <el-table stripe empty-text="暂无xpath推荐语法" border :data="findBestXpath(elementDetail)"
@@ -3045,14 +3052,23 @@ onMounted(() => {
                                   <el-table-column>
                                     <template #default="scope">
                                       <span style="cursor: pointer" @click="copy(scope.row)">{{ scope.row }}</span>
-                                      <a v-if="project && project['id']" style="margin-left: 10px" @click="toAddElement('xpath', scope.row)"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                      <el-icon color="green" size="16" v-if="project && project['id']"
+                                               style="vertical-align: middle;margin-left: 10px"
+                                               @click="toAddElement('xpath', scope.row)">
+                                        <Pointer/>
+                                      </el-icon>
                                     </template>
                                   </el-table-column>
                                 </el-table>
                               </el-form-item>
                               <el-form-item label="绝对路径" style="cursor: pointer">
                                 <span @click="copy(elementDetail['xpath'])">{{ elementDetail['xpath'] }}</span>
-                                <a v-if="project && project['id']"  style="margin-left: 10px" @click="toAddElement('xpath', elementDetail['xpath'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                <el-icon color="green" size="16" v-if="project && project['id']"
+                                         style="vertical-align: middle;margin-left: 10px"
+                                         @click="toAddElement('xpath', elementDetail['xpath'])">
+                                  <Pointer/>
+                                </el-icon>
+
                               </el-form-item>
                               <el-form-item
                                   label="text"
@@ -3077,8 +3093,15 @@ onMounted(() => {
                                 <span>{{ elementDetail['package'] }}</span>
                               </el-form-item>
                               <el-form-item label="中心坐标" style="cursor: pointer">
-                                <span @click="copy(computedCenter(elementDetail['bStart'], elementDetail['bEnd']))">{{ computedCenter(elementDetail['bStart'], elementDetail['bEnd']) }}</span>
-                                <a v-if="project && project['id']" style="margin-left: 10px" @click="toAddElement('point', computedCenter(elementDetail['bStart'], elementDetail['bEnd']))"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                <span @click="copy(computedCenter(elementDetail['bStart'], elementDetail['bEnd']))">{{
+                                    computedCenter(elementDetail['bStart'], elementDetail['bEnd'])
+                                  }}</span>
+                                <el-icon color="green" size="16" v-if="project && project['id']"
+                                         style="vertical-align: middle;margin-left: 10px"
+                                         @click="toAddElement('point', computedCenter(elementDetail['bStart'], elementDetail['bEnd']))">
+                                  <Pointer/>
+                                </el-icon>
+
                               </el-form-item>
                               <el-form-item label="index">
                                 <span>{{ elementDetail['index'] }}</span>

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -3037,7 +3037,7 @@ onMounted(() => {
                                   v-if="elementDetail['resource-id']"
                               >
                                 <span @click="copy(elementDetail['resource-id'])">{{ elementDetail['resource-id'] }}</span>
-                                <a style="margin-left: 10px" @click="toAddElement('id', elementDetail['resource-id'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                <a v-if="project && project['id']" style="margin-left: 10px" @click="toAddElement('id', elementDetail['resource-id'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
                               </el-form-item>
                               <el-form-item label="xpath推荐">
                                 <el-table stripe empty-text="暂无xpath推荐语法" border :data="findBestXpath(elementDetail)"
@@ -3045,14 +3045,14 @@ onMounted(() => {
                                   <el-table-column>
                                     <template #default="scope">
                                       <span style="cursor: pointer" @click="copy(scope.row)">{{ scope.row }}</span>
-                                      <a style="margin-left: 10px" @click="toAddElement('xpath', scope.row)"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                      <a v-if="project && project['id']" style="margin-left: 10px" @click="toAddElement('xpath', scope.row)"><el-icon color="green" size="16"><Pointer /></el-icon></a>
                                     </template>
                                   </el-table-column>
                                 </el-table>
                               </el-form-item>
                               <el-form-item label="绝对路径" style="cursor: pointer">
                                 <span @click="copy(elementDetail['xpath'])">{{ elementDetail['xpath'] }}</span>
-                                <a style="margin-left: 10px" @click="toAddElement('xpath', elementDetail['xpath'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                <a v-if="project && project['id']"  style="margin-left: 10px" @click="toAddElement('xpath', elementDetail['xpath'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
                               </el-form-item>
                               <el-form-item
                                   label="text"
@@ -3078,7 +3078,7 @@ onMounted(() => {
                               </el-form-item>
                               <el-form-item label="中心坐标" style="cursor: pointer">
                                 <span @click="copy(computedCenter(elementDetail['bStart'], elementDetail['bEnd']))">{{ computedCenter(elementDetail['bStart'], elementDetail['bEnd']) }}</span>
-                                <a style="margin-left: 10px" @click="toAddElement('point', computedCenter(elementDetail['bStart'], elementDetail['bEnd']))"><el-icon color="green" size="16"><Pointer /></el-icon></a>
+                                <a v-if="project && project['id']" style="margin-left: 10px" @click="toAddElement('point', computedCenter(elementDetail['bStart'], elementDetail['bEnd']))"><el-icon color="green" size="16"><Pointer /></el-icon></a>
                               </el-form-item>
                               <el-form-item label="index">
                                 <span>{{ elementDetail['index'] }}</span>

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -416,6 +416,14 @@ const copy = (value) => {
     });
   }
 };
+const toAddElement = (eleType, eleValue) => {
+  if (project) {
+    element.value.eleType = eleType
+    element.value.eleValue = eleValue
+    dialogElement.value = true
+  }
+
+}
 const removeScreen = () => {
   screenUrls.value = [];
 };
@@ -1725,7 +1733,7 @@ onMounted(() => {
   </el-dialog>
   <el-dialog v-model="dialogElement" title="控件元素信息" width="600px">
     <element-update v-if="dialogElement" :project-id="project['id']"
-                    :element-id="0" @flush="dialogElement = false"/>
+                    :element-id="0" :element-obj="element" @flush="dialogElement = false"/>
   </el-dialog>
   <el-page-header
       @back="router.go(-1)"
@@ -2986,7 +2994,7 @@ onMounted(() => {
                                 size="small"
                                 type="primary"
                                 round
-                                @click="dialogElement = true"
+                                @click="toAddElement('','')"
                             >添加控件
                             </el-button
                             >
@@ -3027,23 +3035,24 @@ onMounted(() => {
                                   label="resource-id"
                                   style="cursor: pointer"
                                   v-if="elementDetail['resource-id']"
-                                  @click="copy(elementDetail['resource-id'])"
                               >
-                                <span>{{ elementDetail['resource-id'] }}</span>
+                                <span @click="copy(elementDetail['resource-id'])">{{ elementDetail['resource-id'] }}</span>
+                                <a style="margin-left: 10px" @click="toAddElement('id', elementDetail['resource-id'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
                               </el-form-item>
                               <el-form-item label="xpath推荐">
                                 <el-table stripe empty-text="暂无xpath推荐语法" border :data="findBestXpath(elementDetail)"
                                           :show-header="false">
                                   <el-table-column>
                                     <template #default="scope">
-                                      <div style="cursor: pointer" @click="copy(scope.row)">{{ scope.row }}</div>
+                                      <span style="cursor: pointer" @click="copy(scope.row)">{{ scope.row }}</span>
+                                      <a style="margin-left: 10px" @click="toAddElement('xpath', scope.row)"><el-icon color="green" size="16"><Pointer /></el-icon></a>
                                     </template>
                                   </el-table-column>
                                 </el-table>
                               </el-form-item>
-                              <el-form-item label="绝对路径" style="cursor: pointer"
-                                            @click="copy(elementDetail['xpath'])">
-                                <span>{{ elementDetail['xpath'] }}</span>
+                              <el-form-item label="绝对路径" style="cursor: pointer">
+                                <span @click="copy(elementDetail['xpath'])">{{ elementDetail['xpath'] }}</span>
+                                <a style="margin-left: 10px" @click="toAddElement('xpath', elementDetail['xpath'])"><el-icon color="green" size="16"><Pointer /></el-icon></a>
                               </el-form-item>
                               <el-form-item
                                   label="text"
@@ -3067,9 +3076,9 @@ onMounted(() => {
                               >
                                 <span>{{ elementDetail['package'] }}</span>
                               </el-form-item>
-                              <el-form-item label="中心坐标" style="cursor: pointer"
-                                            @click="copy(computedCenter(elementDetail['bStart'], elementDetail['bEnd']))">
-                                <span>{{ computedCenter(elementDetail['bStart'], elementDetail['bEnd']) }}</span>
+                              <el-form-item label="中心坐标" style="cursor: pointer">
+                                <span @click="copy(computedCenter(elementDetail['bStart'], elementDetail['bEnd']))">{{ computedCenter(elementDetail['bStart'], elementDetail['bEnd']) }}</span>
+                                <a style="margin-left: 10px" @click="toAddElement('point', computedCenter(elementDetail['bStart'], elementDetail['bEnd']))"><el-icon color="green" size="16"><Pointer /></el-icon></a>
                               </el-form-item>
                               <el-form-item label="index">
                                 <span>{{ elementDetail['index'] }}</span>


### PR DESCRIPTION
在控件元素页面给resource-id值、xpath推荐值、xpath绝对路径值、坐标值后面添加一个快速添加元素的按钮，可以简化添加元素的步骤
![image](https://user-images.githubusercontent.com/50645139/188042668-79a96d02-486d-4875-9d3c-b7893489fb70.png)
点击添加按钮后自动将定位类型、控件元素值写入元素编辑表单中
![image](https://user-images.githubusercontent.com/50645139/188042706-20c38b6c-def1-40f7-a4ba-72605cb2884b.png)
