### PR TITLE
fix(device-des): 设备在 ONLINE、 DEBUGGING、TESTING 状态下都不可删除

### DIFF
--- a/src/components/DeviceDes.vue
+++ b/src/components/DeviceDes.vue
@@ -460,15 +460,14 @@ const findAgentById = (id) => {
             >
               <template #reference>
                 <el-button
-                  type="danger"
-                  size="mini"
-                  :disabled="
-                    device.status === 'ONLINE' &&
-                    device.status === 'DEBUGGING' &&
-                    device.status === 'TESTING'
-                  "
-                  >{{ $t('common.delete') }}
-                </el-button>
+                    type="danger"
+                    size="mini"
+                    :disabled="device.status === 'ONLINE' ||
+                          device.status === 'DEBUGGING' ||
+                          device.status === 'TESTING'"
+                >{{ $t('common.delete') }}
+                </el-button
+                >
               </template>
             </el-popconfirm>
           </el-form-item>


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（保存后请点击复选框）：**

- [x] 标题为fix、feat或doc开头
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**
之前**删除按钮**的 disable 逻辑为 ：
```js
device.status === 'ONLINE'
                          &&device.status === 'DEBUGGING'
                          &&device.status === 'TESTING'
```
三个 `&&` 绝对存在问题，修改后：
```js
device.status === 'ONLINE' ||
                          device.status === 'DEBUGGING' ||
                          device.status === 'TESTING'
```
仅为**离线**的设备才可以删除
