### PR TITLE
fix: encode brackets in queryparam to resolve nonascii searchwords finds nothing problem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sonic-client-web",
-    "version": "2.0.0",
+    "version": "2.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sonic-client-web",
-            "version": "2.0.0",
+            "version": "2.4.1",
             "dependencies": {
                 "@codemirror/lang-java": "^6.0.0",
                 "@codemirror/lang-python": "^6.0.2",
@@ -20,6 +20,7 @@
                 "less": "^4.1.2",
                 "less-loader": "^10.2.0",
                 "moment": "2.29.1",
+                "qs": "^6.11.1",
                 "rollup-plugin-copy": "3.4.0",
                 "vue": "3.2.14",
                 "vue-clipboard3": "1.0.1",
@@ -3721,6 +3722,20 @@
             "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.11.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+            "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+            "dependencies": {
+                "side-channel": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {
@@ -7473,6 +7488,14 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmmirror.com/punycode/download/punycode-2.1.1.tgz",
             "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+        },
+        "qs": {
+            "version": "6.11.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+            "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+            "requires": {
+                "side-channel": "^1.0.4"
+            }
         },
         "queue-microtask": {
             "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "less": "^4.1.2",
         "less-loader": "^10.2.0",
         "moment": "2.29.1",
+        "qs": "^6.11.1",
         "rollup-plugin-copy": "3.4.0",
         "vue": "3.2.14",
         "vue-clipboard3": "1.0.1",

--- a/src/http/axios.js
+++ b/src/http/axios.js
@@ -16,6 +16,7 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import axios from 'axios';
+import qs from 'qs';
 import { ElMessage } from 'element-plus';
 import { i18n, $tc } from '@/locales/setupI18n';
 import { router } from '../router/index.js';
@@ -33,6 +34,7 @@ $http.defaults.baseURL = baseURL;
 // $http.defaults.timeout = 20000;
 $http.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 $http.defaults.withCredentials = true;
+$http.defaults.paramsSerializer = (params) => qs.stringify(params, { arrayFormat: 'brackets' });
 
 $http.interceptors.request.use(
   (config) => {


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [ ] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [ ] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [ ] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ ] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

服务端升级版本后对url按照rfc3986的新标准进行了更严格的校验，导致如果gateway组件看到url里按规范不能出现[]的时候，会将所有请求参数再次url编码，导致本来已经被编码过一次的get请求参数，中文搜索词等中的%号，发到controller组件时也被连带进行了第二次编码。web容器对中文搜索词进行了一次解码后送入mybatis查询的还是%xx格式的中文，还需再次解码才能和数据库内数据匹配。

前端目前使用的axios版本默认get参数序列化功能未完全符合rfc3986，axios中调整了编码方式的版本还未正式发布。考虑参照axios社区的类似案例使用qs进行请求参数序列化，并设置 arrayFormat: 'brackets' 以保持数组的表示方式不变，仅编码特殊字符。

此方案虽未回退服务端接口的变化，但是可以减少未来潜在的升级兼容问题，建议作为备选。