### PR TITLE
feat：应用程序面板，增加拉取“持续集成设置”->“安装包管理”中app的能力

### DIFF
--- a/src/components/PackageList.vue
+++ b/src/components/PackageList.vue
@@ -1,4 +1,21 @@
 <script setup>
+/*
+ *   sonic-client-web  Front end of Sonic cloud real machine platform.
+ *   Copyright (C) 2022 SonicCloudOrg
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published
+ *   by the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 import { ref, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import Pageable from './Pageable.vue';

--- a/src/components/PackageList.vue
+++ b/src/components/PackageList.vue
@@ -1,0 +1,118 @@
+<script setup>
+import { ref, onMounted, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Pageable from './Pageable.vue';
+import axios from '../http/axios';
+
+const props = defineProps({
+  projectId: Number,
+  platformType: String,
+});
+const { t: $t } = useI18n();
+const pageData = ref({});
+const pageSize = ref(8);
+const pageCurrNum = ref(1);
+const tableLoading = ref(false);
+const branch = ref('');
+const packageName = ref('');
+// 拉取安装包信息的请求
+const getPackageInfoList = (pageNum, pSize) => {
+  tableLoading.value = true;
+  pageSize.value = pSize || pageSize.value;
+  pageCurrNum.value = pageNum || pageCurrNum.value;
+  axios
+    .get('/controller/packages/list', {
+      params: {
+        projectId: props.projectId,
+        platform: props.platformType,
+        page: pageCurrNum.value,
+        pageSize: pageSize.value,
+        branch: branch.value,
+        packageName: packageName.value,
+      },
+    })
+    .then((resp) => {
+      pageData.value = resp.data;
+      tableLoading.value = false;
+    });
+};
+// 点击事件发送
+const emit = defineEmits(['selectPackage']);
+const selectPackage = (row, column, event) => {
+  emit('selectPackage', row.url);
+};
+watch(
+  () => props.projectId,
+  () => {
+    getPackageInfoList();
+  }
+);
+onMounted(() => {
+  getPackageInfoList();
+});
+</script>
+
+<template>
+  <el-table
+    v-loading="tableLoading"
+    :data="pageData['content']"
+    border
+    :row-style="{}"
+    style="margin-top: 15px"
+    @row-click="selectPackage"
+  >
+    <el-table-column
+      width="100"
+      label="id"
+      prop="id"
+      align="center"
+      show-overflow-tooltip
+    />
+    <!--安装包名称列，支持筛选-->>
+    <el-table-column
+      min-width="240"
+      prop="pkgName"
+      header-align="center"
+      show-overflow-tooltip
+    >
+      <template #header>
+        <el-input
+          v-model="packageName"
+          size="mini"
+          :placeholder="$t('packagesTS.packageName')"
+          @input="getPackageInfoList()"
+        />
+      </template>
+    </el-table-column>
+    <!--分支名称列，支持筛选-->>
+    <el-table-column
+      min-width="120"
+      prop="branch"
+      align="center"
+    >
+    <template #header>
+        <el-input
+          v-model="branch"
+          size="mini"
+          :placeholder="$t('packagesTS.branch')"
+          @input="getPackageInfoList()"
+        />
+      </template>
+    </el-table-column>
+    <!--更新时间列-->>
+    <el-table-column
+      min-width="80"
+      :label="$t('packagesTS.updateTime')"
+      prop="updateTime"
+      align="center"
+      show-overflow-tooltip
+    />
+  </el-table>
+  <pageable
+    :is-page-set="false"
+    :total="pageData['totalElements']"
+    :current-page="pageData['number'] + 1"
+    :page-size="pageData['size']"
+    @change="getPackageInfoList"
+  ></pageable>
+</template>

--- a/src/locales/lang/en_US.js
+++ b/src/locales/lang/en_US.js
@@ -527,6 +527,7 @@ const packagesTS = {
   downloadLink: 'Download Link',
   copyUrl: 'Copy url',
   creatTime: 'Created Time',
+  updateTime: 'Update Time',
 };
 const projectIndexTS = {
   code: {
@@ -774,6 +775,8 @@ const androidRemoteTS = {
     apkFile: 'Drag the APK file here, or',
     onlyAPKFile: 'Only upload apk files',
     URLInstall: 'Install via URL',
+    linkInstall: 'Install via Jenkins Plugin Upload',
+    hintAssociatedProject: 'This feature requires first associating the project from above',
     hint: 'Please input apk download link or local path',
     refresh: 'Refresh',
     appName: 'APP Name',

--- a/src/locales/lang/ja_JP.js
+++ b/src/locales/lang/ja_JP.js
@@ -515,6 +515,7 @@ const packagesTS = {
   downloadLink: '下载地址',
   copyUrl: '复制url',
   creatTime: '创建时间',
+  updateTime: '更新时间',
 };
 const projectIndexTS = {
   code: {
@@ -756,6 +757,8 @@ const androidRemoteTS = {
     apkFile: '将APK文件拖到此处，或',
     onlyAPKFile: '只能上传apk文件',
     URLInstall: 'URL安装',
+    linkInstall: '持续集成管理安装',
+    hintAssociatedProject: '该功能需要先从上方关联项目',
     hint: '请输入apk下载链接或本地路径',
     refresh: '刷新',
     appName: '应用名',

--- a/src/locales/lang/zh_CN.js
+++ b/src/locales/lang/zh_CN.js
@@ -513,6 +513,7 @@ const packagesTS = {
   downloadLink: '下载地址',
   copyUrl: '复制url',
   creatTime: '创建时间',
+  updateTime: '更新时间',
 };
 const projectIndexTS = {
   code: {
@@ -754,6 +755,8 @@ const androidRemoteTS = {
     apkFile: '将APK文件拖到此处，或',
     onlyAPKFile: '只能上传apk文件',
     URLInstall: 'URL安装',
+    linkInstall: '持续集成管理安装',
+    hintAssociatedProject: '该功能需要先从上方关联项目',
     hint: '请输入apk下载链接或本地路径',
     refresh: '刷新',
     appName: '应用名',

--- a/src/locales/lang/zh_TW.js
+++ b/src/locales/lang/zh_TW.js
@@ -513,6 +513,7 @@ const packagesTS = {
   downloadLink: '下載連結',
   copyUrl: '複製url',
   creatTime: '創立時間',
+  updateTime: '更新時間',
 };
 const projectIndexTS = {
   code: {
@@ -754,6 +755,8 @@ const androidRemoteTS = {
     apkFile: '將APK文件拖到此處，或',
     onlyAPKFile: '只能上傳apk檔',
     URLInstall: 'URL安裝',
+    linkInstall: '持續集成管理安裝',
+    hintAssociatedProject: '該功能需要先從上方關聯項目',
     hint: '請輸入apk下載連結或本地路徑',
     refresh: '刷新',
     appName: 'App名稱',

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -2824,7 +2824,7 @@ const checkAlive = () => {
                   <package-list
                     v-if="project !== null"
                     :projectId="project['id']"
-                    :platformType="'Android'"
+                    platformType="Android"
                     @select-package="selectPackage"
                   ></package-list>
                 </div>

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -35,6 +35,7 @@ import TestCaseList from '@/components/TestCaseList.vue';
 import StepLog from '@/components/StepLog.vue';
 import ElementUpdate from '@/components/ElementUpdate.vue';
 import Pageable from '@/components/Pageable.vue';
+import PackageList from '@/components/PackageList.vue';
 import defaultLogo from '@/assets/logo.png';
 import {
   VideoPause,
@@ -343,6 +344,18 @@ const getImg = (name) => {
   }
   return result;
 };
+// 选中安装包列表中的item后响应事件
+const selectPackage = (val) => {
+  ElMessage.success({
+    message: $t('androidRemoteTS.startInstall'),
+  });
+  install(val)
+};
+// 三种安装包方式tab选中态
+const activeIntallTab = ref('pushInstallPane');
+const intallTabClick = (e) => {
+  activeIntallTab.value = e.props.name;
+}
 watch(filterText, (newValue, oldValue) => {
   tree.value.filter(newValue);
 });
@@ -2720,15 +2733,14 @@ const checkAlive = () => {
             </el-row>
           </el-tab-pane>
           <el-tab-pane :label="$t('androidRemoteTS.code.app')" name="apps">
-            <el-row :gutter="20">
-              <el-col :span="12">
-                <el-card shadow="hover">
-                  <template #header>
+            <el-tabs type="border-card" stretch=true v-model="activeIntallTab" @tab-click="intallTabClick">
+              <el-tab-pane name="pushInstallPane">
+                <template #label>
                     <strong>{{
                       $t('androidRemoteTS.code.pushInstall')
                     }}</strong>
-                  </template>
-                  <div style="text-align: center">
+                </template>
+                <div style="text-align: center">
                     <el-upload
                       v-loading="uploadLoading"
                       drag
@@ -2750,27 +2762,15 @@ const checkAlive = () => {
                         </div>
                       </template>
                     </el-upload>
-                  </div>
-                </el-card>
-              </el-col>
-              <el-col :span="12">
-                <el-card
-                  shadow="hover"
-                  class="url-install-box"
-                  :body-style="{
-                    position: 'absolute',
-                    top: '50%',
-                    width: '100%',
-                    paddingTop: '56px',
-                    paddingBottom: '0',
-                    boxSizing: 'border-box',
-                    transform: 'translateY(-50%)',
-                  }"
-                >
-                  <template #header>
-                    <strong>{{ $t('androidRemoteTS.code.URLInstall') }}</strong>
-                  </template>
-                  <el-input
+                </div>
+              </el-tab-pane>
+              <el-tab-pane name="urlInstallPane">
+                <template #label>
+                    <strong>{{
+                      $t('androidRemoteTS.code.URLInstall')
+                    }}</strong>
+                </template>
+                <el-input
                     v-model="uploadUrl"
                     clearable
                     size="small"
@@ -2785,9 +2785,63 @@ const checkAlive = () => {
                       >{{ $t('androidRemoteTS.code.send') }}
                     </el-button>
                   </div>
-                </el-card>
-              </el-col>
-            </el-row>
+              </el-tab-pane>
+              <el-tab-pane name="linkInstallPane">
+                <template #label>
+                    <strong>{{
+                      $t('androidRemoteTS.code.linkInstall')
+                    }}</strong>
+                </template>
+                  <span style="color: #909399; margin-right: 10px">{{
+                  $t('androidRemoteTS.code.associatedProject')
+                }}</span>
+                <el-select
+                  v-model="project"
+                  size="mini"
+                  value-key="id"
+                  :placeholder="$t('androidRemoteTS.code.chooseProject')"
+                >
+                  <el-option
+                    v-for="item in store.state.projectList"
+                    :key="item.id"
+                    :value="item"
+                    :label="item['projectName']"
+                  >
+                    <div style="display: flex; align-items: center">
+                      <el-avatar
+                        style="margin-right: 10px"
+                        :size="32"
+                        :src="
+                          item['projectImg'].length > 0
+                            ? item['projectImg']
+                            : defaultLogo
+                        "
+                        shape="square"
+                      ></el-avatar>
+                      {{ item['projectName'] }}
+                    </div>
+                  </el-option>
+                </el-select>
+
+                <div v-if="project !== null">
+                  <package-list
+                    v-if="project !== null"
+                    :projectId="project['id']"
+                    :platformType="'Android'"
+                    @select-package="selectPackage"
+                  ></package-list>
+                </div>
+                <div v-else>
+                  <el-card style="height: 100%; margin-top: 20px">
+                    <el-result
+                    icon="info"
+                    :title="$t('androidRemoteTS.code.hintText')"
+                    :sub-title="$t('androidRemoteTS.code.hintAssociatedProject')">
+                    </el-result>
+                  </el-card>
+                </div>
+              </el-tab-pane>
+            </el-tabs>
             <el-card shadow="hover" style="margin-top: 15px">
               <el-table :data="currAppListPageData" border>
                 <el-table-column width="100" header-align="center">

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -353,9 +353,6 @@ const selectPackage = (val) => {
 };
 // 三种安装包方式tab选中态
 const activeIntallTab = ref('pushInstallPane');
-const intallTabClick = (e) => {
-  activeIntallTab.value = e.props.name;
-}
 watch(filterText, (newValue, oldValue) => {
   tree.value.filter(newValue);
 });
@@ -2733,7 +2730,7 @@ const checkAlive = () => {
             </el-row>
           </el-tab-pane>
           <el-tab-pane :label="$t('androidRemoteTS.code.app')" name="apps">
-            <el-tabs type="border-card" stretch=true v-model="activeIntallTab" @tab-click="intallTabClick">
+            <el-tabs type="border-card" stretch v-model="activeIntallTab">
               <el-tab-pane name="pushInstallPane">
                 <template #label>
                     <strong>{{

--- a/src/views/RemoteEmulator/IOSRemote.vue
+++ b/src/views/RemoteEmulator/IOSRemote.vue
@@ -382,11 +382,7 @@ const selectPackage = (val) => {
   });
   install(val)
 };
-// 三种安装包方式tab选中态
 const activeIntallTab = ref('pushInstallPane');
-const intallTabClick = (e) => {
-  activeIntallTab.value = e.props.name;
-}
 watch(filterText, (newValue, oldValue) => {
   tree.value.filter(newValue);
 });
@@ -1900,7 +1896,7 @@ const checkAlive = () => {
             </el-row>
           </el-tab-pane>
           <el-tab-pane :label="$t('androidRemoteTS.code.app')" name="apps">
-            <el-tabs type="border-card" stretch=true v-model="activeIntallTab" @tab-click="intallTabClick">
+            <el-tabs type="border-card" stretch v-model="activeIntallTab">
               <el-tab-pane name="pushInstallPane">
                 <template #label>
                     <strong>{{

--- a/src/views/RemoteEmulator/IOSRemote.vue
+++ b/src/views/RemoteEmulator/IOSRemote.vue
@@ -73,6 +73,7 @@ import RenderDeviceName from '../../components/RenderDeviceName.vue';
 import PocoPane from '../../components/PocoPane.vue';
 import IOSPerf from '../../components/IOSPerf.vue';
 import RemotePageHeader from '../../components/RemotePageHeader.vue';
+import PackageList from '@/components/PackageList.vue';
 
 const pocoPaneRef = ref(null);
 const iosPerfRef = ref(null);
@@ -374,6 +375,18 @@ const getImg = (name) => {
   }
   return result;
 };
+// 选中安装包列表中的item后响应事件
+const selectPackage = (val) => {
+  ElMessage.success({
+    message: $t('androidRemoteTS.startInstall'),
+  });
+  install(val)
+};
+// 三种安装包方式tab选中态
+const activeIntallTab = ref('pushInstallPane');
+const intallTabClick = (e) => {
+  activeIntallTab.value = e.props.name;
+}
 watch(filterText, (newValue, oldValue) => {
   tree.value.filter(newValue);
 });
@@ -1887,13 +1900,14 @@ const checkAlive = () => {
             </el-row>
           </el-tab-pane>
           <el-tab-pane :label="$t('androidRemoteTS.code.app')" name="apps">
-            <el-row :gutter="20">
-              <el-col :span="12">
-                <el-card shadow="hover">
-                  <template #header>
-                    <strong>{{ $t('IOSRemote.installIPA') }}</strong>
-                  </template>
-                  <div style="text-align: center">
+            <el-tabs type="border-card" stretch=true v-model="activeIntallTab" @tab-click="intallTabClick">
+              <el-tab-pane name="pushInstallPane">
+                <template #label>
+                    <strong>{{
+                      $t('IOSRemote.installIPA')
+                    }}</strong>
+                </template>
+                <div style="text-align: center">
                     <el-upload
                       v-loading="uploadLoading"
                       drag
@@ -1916,26 +1930,15 @@ const checkAlive = () => {
                       </template>
                     </el-upload>
                   </div>
-                </el-card>
-              </el-col>
-              <el-col :span="12">
-                <el-card
-                  shadow="hover"
-                  class="url-install-box"
-                  :body-style="{
-                    position: 'absolute',
-                    top: '50%',
-                    width: '100%',
-                    paddingTop: '56px',
-                    paddingBottom: '0',
-                    boxSizing: 'border-box',
-                    transform: 'translateY(-50%)',
-                  }"
-                >
-                  <template #header>
-                    <strong>URL安装</strong>
-                  </template>
-                  <el-input
+              </el-tab-pane>
+
+              <el-tab-pane name="urlInstallPane">
+                <template #label>
+                    <strong>{{
+                      $t('androidRemoteTS.code.URLInstall')
+                    }}</strong>
+                </template>
+                <el-input
                     v-model="uploadUrl"
                     clearable
                     size="small"
@@ -1950,9 +1953,64 @@ const checkAlive = () => {
                       >{{ $t('androidRemoteTS.code.send') }}
                     </el-button>
                   </div>
-                </el-card>
-              </el-col>
-            </el-row>
+              </el-tab-pane>
+              <el-tab-pane name="linkInstallPane">
+                <template #label>
+                    <strong>{{
+                      $t('androidRemoteTS.code.linkInstall')
+                    }}</strong>
+                </template>
+                  <span style="color: #909399; margin-right: 10px">{{
+                  $t('androidRemoteTS.code.associatedProject')
+                }}</span>
+                <el-select
+                  v-model="project"
+                  size="mini"
+                  value-key="id"
+                  :placeholder="$t('androidRemoteTS.code.chooseProject')"
+                >
+                  <el-option
+                    v-for="item in store.state.projectList"
+                    :key="item.id"
+                    :value="item"
+                    :label="item['projectName']"
+                  >
+                    <div style="display: flex; align-items: center">
+                      <el-avatar
+                        style="margin-right: 10px"
+                        :size="32"
+                        :src="
+                          item['projectImg'].length > 0
+                            ? item['projectImg']
+                            : defaultLogo
+                        "
+                        shape="square"
+                      ></el-avatar>
+                      {{ item['projectName'] }}
+                    </div>
+                  </el-option>
+                </el-select>
+
+                <div v-if="project !== null">
+                  <package-list
+                    v-if="project !== null"
+                    :projectId="project['id']"
+                    :platformType="'ios'"
+                    @select-package="selectPackage"
+                  ></package-list>
+                </div>
+                <div v-else>
+                  <el-card style="height: 100%; margin-top: 20px">
+                    <el-result
+                    icon="info"
+                    :title="$t('androidRemoteTS.code.hintText')"
+                    :sub-title="$t('androidRemoteTS.code.hintAssociatedProject')">
+                    </el-result>
+                  </el-card>
+                </div>
+              </el-tab-pane>
+            </el-tabs>
+
             <el-card shadow="hover" style="margin-top: 15px">
               <el-table :data="currAppListPageData" border>
                 <el-table-column width="100" header-align="center">

--- a/src/views/RemoteEmulator/IOSRemote.vue
+++ b/src/views/RemoteEmulator/IOSRemote.vue
@@ -1991,7 +1991,7 @@ const checkAlive = () => {
                   <package-list
                     v-if="project !== null"
                     :projectId="project['id']"
-                    :platformType="'ios'"
+                    platformType="iOS"
                     @select-package="selectPackage"
                   ></package-list>
                 </div>


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

应用程序面板，新增加tab，通过选择持续集成安装包管理的方式进行安装。
前端改造：修改Android与ios端的“应用程序”面板，增加一个独立的vue组件，拉取指定项目下的安装包列表，用户选择特定的item之后，复用URL安装的方式，发送给agent端进行安装，

相关需求细节在社区中简单沟通：https://sonic-cloud.wiki/d/3064-app
