### PR TITLE
feat:Android端控件树dump页面，支持通过快捷按钮将content-desc属性添加到控件元素信息

### DIFF
--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -3761,9 +3761,26 @@ const checkAlive = () => {
                                 v-if="elementDetail['content-desc']"
                                 label="content-desc"
                                 style="cursor: pointer"
-                                @click="copy(elementDetail['content-desc'])"
                               >
-                                <span>{{ elementDetail['content-desc'] }}</span>
+                                <span @click="copy(elementDetail['content-desc'])">{{ elementDetail['content-desc'] }}</span>
+                                <el-icon
+                                  v-if="project && project['id']"
+                                  color="green"
+                                  size="16"
+                                  style="
+                                    vertical-align: middle;
+                                    margin-left: 10px;
+                                    cursor: pointer;
+                                  "
+                                  @click="
+                                    toAddElement(
+                                      'accessibilityId',
+                                      elementDetail['content-desc']
+                                    )
+                                  "
+                                >
+                                <Pointer />
+                                </el-icon>
                               </el-form-item>
                               <el-form-item
                                 label="package"


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

Android端通过`content-desc`进行元素查找也比较常用，目前sonic平台录入元素的过程中，支持选择定位类型为`accessibilityId`，但是在控件树dump界面录入的时候，`content-desc`属性后没有增加的小箭头，这里简单优化支持下，效果如下：

<img width="486" alt="截图_d104bf07-6d77-447b-936f-c6359502f038" src="https://github.com/SonicCloudOrg/sonic-client-web/assets/15340677/3d52ca5c-0d38-4f03-9650-ad9c14563358">

点击后：

<img width="644" alt="截图_0076f950-1b61-4d4a-9076-99270f8c3bc8" src="https://github.com/SonicCloudOrg/sonic-client-web/assets/15340677/874415cf-b601-4e21-9e73-ca2cd6ad5c57">

目前agent端是直接支持的，前端放出相关入口就好，自测正常。


