### PR TITLE
feat:实现断言验证(不相等)的前端ui

### DIFF
--- a/src/components/StepShow.vue
+++ b/src/components/StepShow.vue
@@ -478,6 +478,10 @@ const getNotes = (text, type) => {
     <el-tag type="warning" size="small">断言验证(相等)</el-tag>
     真实值：{{ step.text }} 期望值：{{ step.content }}
   </span>
+  <span v-if="step.stepType === 'assertNotEquals'">
+    <el-tag type="warning" size="small">断言验证(不相等)</el-tag>
+    真实值：{{ step.text }} 期望值：{{ step.content }}
+  </span>
   <span v-if="step.stepType === 'assertTrue'">
     <el-tag type="warning" size="small">断言验证(包含)</el-tag>
     真实值：{{ step.text }} 期望值：{{ step.content }}

--- a/src/components/StepUpdate.vue
+++ b/src/components/StepUpdate.vue
@@ -713,6 +713,10 @@ const androidOptions = ref([
             label: '断言验证(相等)',
           },
           {
+            value: 'assertNotEquals',
+            label: '断言验证(不相等)',
+          },
+          {
             value: 'assertTrue',
             label: '断言验证(包含)',
           },
@@ -1023,6 +1027,10 @@ const iOSOptions = ref([
           {
             value: 'assertEquals',
             label: '断言验证(相等)',
+          },
+          {
+            value: 'assertNotEquals',
+            label: '断言验证(不相等)',
           },
           {
             value: 'assertTrue',
@@ -2258,6 +2266,7 @@ onMounted(() => {
       <div
         v-if="
           step.stepType === 'assertEquals' ||
+          step.stepType === 'assertNotEquals' ||
           step.stepType === 'assertTrue' ||
           step.stepType === 'assertNotTrue'
         "


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

前端增加支持：断言验证(不相等)的类型，扩充相关指令
社区有相关需求反馈，[校验断言中希望可以加个【不相等】的断言，只有不包含不太够用](https://sonic-cloud.wiki/d/2689)
我们内部的项目也有相关的需求，尝试实现了一下。
