### PR TITLE
feat,将原有的“验证文本”改为“断言文本”，允许指定比较方式为等于，不等于，包含，不包含四种模式，满足更丰富的应用场景

### DIFF
--- a/src/components/StepShow.vue
+++ b/src/components/StepShow.vue
@@ -55,15 +55,17 @@ const getPublicStepInfo = (id) => {
 };
 
 const getAssertTextOpe = (s) => {
-  const ss = s.toUpperCase();
-  if (s === 'equal') {
-    return '等于';
-  } else if (s === 'notEqual') {
-    return '不等于';
-  } else if (s === 'contain') {
-    return '包含';
-  } else {
-    return '不包含';
+  switch (s) {
+    case 'equal':
+      return '等于';
+    case 'notEqual':
+      return '不等于';
+    case 'contain':
+      return '包含';
+    case 'notContain':
+      return '不包含';
+    default:
+      return '未知类型';
   }
 };
 

--- a/src/components/StepShow.vue
+++ b/src/components/StepShow.vue
@@ -54,6 +54,19 @@ const getPublicStepInfo = (id) => {
   });
 };
 
+const getAssertTextOpe = (s) => {
+  const ss = s.toUpperCase();
+  if (s === 'equal') {
+    return '等于';
+  } else if (s === 'notEqual') {
+    return '不等于';
+  } else if (s === 'contain') {
+    return '包含';
+  } else {
+    return '不包含';
+  }
+};
+
 const getEleResult = (s) => {
   const ss = s.toUpperCase();
   if (ss.indexOf('POCO') !== -1) {
@@ -439,6 +452,7 @@ const getNotes = (text, type) => {
     <el-tag size="small">获取剪切板文本</el-tag>
     获取到变量：{{ step.content }}
   </span>
+  <!--三个指令前端显示上保留，用于兼容老版本升级上来之后，依然能正常的显示和运行-->
   <span
     v-if="
       step.stepType === 'getText' ||
@@ -454,6 +468,23 @@ const getNotes = (text, type) => {
       >{{ step.elements[0]['eleName'] }}</el-tag
     >
     期望值：{{ step.content }}
+  </span>
+    <!--大于2.5.0版本，增强的文本断言能力-->
+    <span
+    v-if="
+      step.stepType === 'assertText' ||
+      step.stepType === 'assertWebViewText' ||
+      step.stepType === 'assertPocoText'
+    "
+  >
+    <el-tag size="small">断言{{ getEleResult(step.stepType) }}文本</el-tag>
+    <el-tag
+      type="info"
+      size="small"
+      style="margin-left: 10px; margin-right: 10px"
+      >{{ step.elements[0]['eleName'] }}</el-tag
+    > 期望: 
+    <el-tag size="small" style="margin-left: 10px; margin-right: 10px">{{ getAssertTextOpe(step.content) }}</el-tag>{{ step.text }}
   </span>
   <span v-if="step.stepType === 'getTitle'">
     <el-tag size="small" style="margin-right: 10px">验证标题</el-tag>

--- a/src/components/StepUpdate.vue
+++ b/src/components/StepUpdate.vue
@@ -1032,10 +1032,6 @@ const iOSOptions = ref([
             label: '获取文本',
           },
           {
-            value: 'getPocoText',
-            label: '验证文本',
-          },
-          {
             value: 'assertPocoText',
             label: '断言文本',
           },
@@ -2113,32 +2109,14 @@ onMounted(() => {
 
       <!--这里UI上还需要保留，用于在老版本升级上来之后，可以编辑用-->
       <div
-        v-if="step.stepType === 'getText' || step.stepType === 'getWebViewText'"
+        v-if="step.stepType === 'assertText' || step.stepType === 'assertWebViewText' || step.stepType === 'assertPocoText'" 
       >
         <element-select
           label="控件元素"
           place="请选择控件元素"
           :index="0"
           :project-id="projectId"
-          type="normal"
-          :step="step"
-        />
-        <el-form-item label="期望值">
-          <el-input
-            v-model="step.content"
-            placeholder="请输入期望值"
-          ></el-input>
-        </el-form-item>
-      </div>
-
-      <!--这里UI上还需要保留，用于在老版本升级上来之后，可以编辑用-->
-      <div v-if="step.stepType === 'getPocoText'">
-        <element-select
-          label="控件元素"
-          place="请选择控件元素"
-          :index="0"
-          :project-id="projectId"
-          type="poco"
+          :type="step.stepType === 'assertPocoText' ? 'poco' : 'normal'"
           :step="step"
         />
         <el-form-item label="期望值">
@@ -2151,47 +2129,14 @@ onMounted(() => {
 
       <!-- >2.5版本之后，增强类型的文本断言 -->
       <div
-        v-if="step.stepType === 'assertText' || step.stepType === 'assertWebViewText'"
+        v-if="step.stepType === 'assertText' || step.stepType === 'assertWebViewText' || step.stepType === 'assertPocoText'" 
       >
         <element-select
           label="控件元素"
           place="请选择控件元素"
           :index="0"
           :project-id="projectId"
-          type="normal"
-          :step="step"
-        />
-        <el-form-item
-          label="断言类型"
-          prop="content"
-          :rules="{required: true, message: '断言类型不能为空', trigger: 'change'}"
-        >
-          <el-select v-model="step.content">
-            <el-option label="等于" value="equal"></el-option>
-            <el-option label="不等于" value="notEqual"></el-option>
-            <el-option label="包含" value="contain"></el-option>
-            <el-option label="不包含" value="notContain"></el-option>
-          </el-select>
-        </el-form-item>
-        <el-form-item 
-          label="期望值"
-          prop="text"
-          :rules="{required: true, message: '期望值不能为空', trigger: 'change'}">
-          <el-input
-            v-model="step.text"
-            placeholder="请输入期望值"
-          ></el-input>
-        </el-form-item>
-      </div>
-
-      <!-- >2.5版本之后，增强类型的文本断言 -->
-      <div v-if="step.stepType === 'assertPocoText'">
-        <element-select
-          label="控件元素"
-          place="请选择控件元素"
-          :index="0"
-          :project-id="projectId"
-          type="poco"
+          :type="step.stepType === 'assertPocoText' ? 'poco' : 'normal'"
           :step="step"
         />
         <el-form-item

--- a/src/components/StepUpdate.vue
+++ b/src/components/StepUpdate.vue
@@ -550,10 +550,6 @@ const androidOptions = ref([
             label: '获取文本',
           },
           {
-            value: 'getText',
-            label: '验证文本',
-          },
-          {
             value: 'assertText',
             label: '断言文本',
           },
@@ -628,10 +624,6 @@ const androidOptions = ref([
           {
             value: 'getWebViewTextValue',
             label: '获取文本',
-          },
-          {
-            value: 'getWebViewText',
-            label: '验证文本',
           },
           {
             value: 'assertWebViewText',
@@ -710,10 +702,6 @@ const androidOptions = ref([
           {
             value: 'getPocoTextValue',
             label: '获取文本',
-          },
-          {
-            value: 'getPocoText',
-            label: '验证文本',
           },
           {
             value: 'assertPocoText',
@@ -954,10 +942,6 @@ const iOSOptions = ref([
           {
             value: 'getTextValue',
             label: '获取文本',
-          },
-          {
-            value: 'getText',
-            label: '验证文本',
           },
           {
             value: 'assertText',

--- a/src/components/StepUpdate.vue
+++ b/src/components/StepUpdate.vue
@@ -356,6 +356,14 @@ const getStepInfo = (id) => {
         monkey.value = JSON.parse(step.value.content);
         activityList.value = JSON.parse(step.value.text);
       }
+      if (
+        step.value.stepType === 'assertText' ||
+        step.value.stepType === 'assertWebViewText' || 
+        step.value.stepType === 'assertPocoText'
+      ) {
+        step.value.content = JSON.parse(step.value.content);
+        step.value.text = JSON.parse(step.value.text);
+      }
     });
 };
 const publicStepList = ref([]);
@@ -546,6 +554,10 @@ const androidOptions = ref([
             label: '验证文本',
           },
           {
+            value: 'assertText',
+            label: '断言文本',
+          },
+          {
             value: 'logElementAttr',
             label: '日志输出控件信息',
           },
@@ -620,6 +632,10 @@ const androidOptions = ref([
           {
             value: 'getWebViewText',
             label: '验证文本',
+          },
+          {
+            value: 'assertWebViewText',
+            label: '断言文本',
           },
           {
             value: 'getTitle',
@@ -698,6 +714,10 @@ const androidOptions = ref([
           {
             value: 'getPocoText',
             label: '验证文本',
+          },
+          {
+            value: 'assertPocoText',
+            label: '断言文本',
           },
           {
             value: 'logPocoElementAttr',
@@ -940,6 +960,10 @@ const iOSOptions = ref([
             label: '验证文本',
           },
           {
+            value: 'assertText',
+            label: '断言文本',
+          },
+          {
             value: 'logElementAttr',
             label: '日志输出控件信息',
           },
@@ -1026,6 +1050,10 @@ const iOSOptions = ref([
           {
             value: 'getPocoText',
             label: '验证文本',
+          },
+          {
+            value: 'assertPocoText',
+            label: '断言文本',
           },
           {
             value: 'logPocoElementAttr',
@@ -2099,6 +2127,7 @@ onMounted(() => {
         </el-form-item>
       </div>
 
+      <!--这里UI上还需要保留，用于在老版本升级上来之后，可以编辑用-->
       <div
         v-if="step.stepType === 'getText' || step.stepType === 'getWebViewText'"
       >
@@ -2118,6 +2147,7 @@ onMounted(() => {
         </el-form-item>
       </div>
 
+      <!--这里UI上还需要保留，用于在老版本升级上来之后，可以编辑用-->
       <div v-if="step.stepType === 'getPocoText'">
         <element-select
           label="控件元素"
@@ -2135,6 +2165,73 @@ onMounted(() => {
         </el-form-item>
       </div>
 
+      <!-- >2.5版本之后，增强类型的文本断言 -->
+      <div
+        v-if="step.stepType === 'assertText' || step.stepType === 'assertWebViewText'"
+      >
+        <element-select
+          label="控件元素"
+          place="请选择控件元素"
+          :index="0"
+          :project-id="projectId"
+          type="normal"
+          :step="step"
+        />
+        <el-form-item
+          label="断言类型"
+          prop="content"
+          :rules="{required: true, message: '断言类型不能为空', trigger: 'change'}"
+        >
+          <el-select v-model="step.content">
+            <el-option label="等于" value="equal"></el-option>
+            <el-option label="不等于" value="notEqual"></el-option>
+            <el-option label="包含" value="contain"></el-option>
+            <el-option label="不包含" value="notContain"></el-option>
+          </el-select>
+        </el-form-item>
+        <el-form-item 
+          label="期望值"
+          prop="text"
+          :rules="{required: true, message: '期望值不能为空', trigger: 'change'}">
+          <el-input
+            v-model="step.text"
+            placeholder="请输入期望值"
+          ></el-input>
+        </el-form-item>
+      </div>
+
+      <!-- >2.5版本之后，增强类型的文本断言 -->
+      <div v-if="step.stepType === 'assertPocoText'">
+        <element-select
+          label="控件元素"
+          place="请选择控件元素"
+          :index="0"
+          :project-id="projectId"
+          type="poco"
+          :step="step"
+        />
+        <el-form-item
+          label="断言类型"
+          prop="content"
+          :rules="{required: true, message: '断言类型不能为空', trigger: 'change'}"
+        >
+          <el-select v-model="step.content">
+            <el-option label="等于" value="equal"></el-option>
+            <el-option label="不等于" value="notEqual"></el-option>
+            <el-option label="包含" value="contain"></el-option>
+            <el-option label="不包含" value="notContain"></el-option>
+          </el-select>
+        </el-form-item>
+        <el-form-item 
+          label="期望值"
+          prop="text"
+          :rules="{required: true, message: '期望值不能为空', trigger: 'change'}">
+          <el-input
+            v-model="step.text"
+            placeholder="请输入期望值"
+          ></el-input>
+        </el-form-item>
+      </div>
       <div v-if="step.stepType === 'getTitle' || step.stepType === 'getUrl'">
         <el-form-item label="期望值">
           <el-input

--- a/src/components/StepUpdate.vue
+++ b/src/components/StepUpdate.vue
@@ -2109,14 +2109,14 @@ onMounted(() => {
 
       <!--这里UI上还需要保留，用于在老版本升级上来之后，可以编辑用-->
       <div
-        v-if="step.stepType === 'assertText' || step.stepType === 'assertWebViewText' || step.stepType === 'assertPocoText'" 
+        v-if="step.stepType === 'getText' || step.stepType === 'getWebViewText' || step.stepType === 'getPocoText'" 
       >
         <element-select
           label="控件元素"
           place="请选择控件元素"
           :index="0"
           :project-id="projectId"
-          :type="step.stepType === 'assertPocoText' ? 'poco' : 'normal'"
+          :type="step.stepType === 'getPocoText' ? 'poco' : 'normal'"
           :step="step"
         />
         <el-form-item label="期望值">


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

[Agent端已提交的pr](https://github.com/SonicCloudOrg/sonic-agent/pull/348)，同步的web端UI变更
