### PR TITLE
fix: workaround for knife4j doc base path

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -32,6 +32,10 @@ http {
         	proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
         }
+		location /server/v3/api-docs/swagger-config {
+		    #WORKAROUND fixed knife4j doc base path
+                    return 200 '{"configUrl":"/server/v3/api-docs/swagger-config","oauth2RedirectUrl":"","operationsSorter":"alpha","tagsSorter":"alpha","urls":[{"name":"sonic-server-controller","serviceName":"sonic-server-controller","url":"/server/api/controller/v3/api-docs?group=default","contextPath":"/server/api/controller","order":1},{"name":"sonic-server-folder","serviceName":"sonic-server-folder","url":"/server/api/folder/v3/api-docs?group=default","contextPath":"/server/api/folder","order":2}],"validatorUrl":""}';
+                }
 
 		location /chrome/ {
         	proxy_pass http://localhost:9222/;


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [ ] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [ ] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [ ] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ ] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

临时解决knife4j生成的文档基础路径异常问题，nginx直接返回固定内容替代。

备注：这只是一个短期替代方案，后续建议调整服务端路径规划，避免使用nginx改写去除/server/路径，以使得开发环境与正式环境一致