### PR TITLE
fix：远控页面加载时判断是否为刷新，避免因资源未释放页面直接闪退

### DIFF
--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -1694,9 +1694,26 @@ const getProjectList = () => {
     store.commit('saveProjectList', resp.data);
   });
 };
-let activeTime = 0;
-const idleCount = ref(0);
-onMounted(() => {
+/**
+ * 刷新不闪退-判断页面是否刷新
+ */
+function sleep(time){
+ return new Promise(function(resolve){
+ setTimeout(resolve, time);
+ });
+}
+const judgeLoad = async () => {
+  if(window.name == ""){
+  // 首次加载;
+   mountedHandle();
+   window.name = "isReload"; 
+   }else if(window.name == "isReload"){
+  // 页面被刷新;
+   await sleep(1500);
+   mountedHandle();
+  }
+}
+const mountedHandle = () =>{
   if (store.state.project.id) {
     project.value = store.state.project;
   } else {
@@ -1704,6 +1721,11 @@ onMounted(() => {
   }
   getDeviceById(route.params.deviceId);
   store.commit('autoChangeCollapse');
+}
+let activeTime = 0;
+const idleCount = ref(0);
+onMounted(() => {
+  judgeLoad();
   getRemoteTimeout();
   getIdleTimeout();
   activeTime = new Date().getTime();

--- a/src/views/RemoteEmulator/IOSRemote.vue
+++ b/src/views/RemoteEmulator/IOSRemote.vue
@@ -1237,9 +1237,26 @@ const getProjectList = () => {
     store.commit('saveProjectList', resp.data);
   });
 };
-let activeTime = 0;
-const idleCount = ref(0);
-onMounted(() => {
+/**
+ * 刷新不闪退-判断页面是否刷新
+ */
+ function sleep(time){
+ return new Promise(function(resolve){
+ setTimeout(resolve, time);
+ });
+}
+const judgeLoad = async () => {
+  if(window.name == ""){
+  // 首次加载;
+   mountedHandle();
+   window.name = "isReload"; 
+   }else if(window.name == "isReload"){
+  // 页面被刷新;
+   await sleep(1500);
+   mountedHandle();
+  }
+}
+const mountedHandle = () =>{
   if (store.state.project.id) {
     project.value = store.state.project;
   } else {
@@ -1247,6 +1264,11 @@ onMounted(() => {
   }
   getDeviceById(route.params.deviceId);
   store.commit('autoChangeCollapse');
+}
+let activeTime = 0;
+const idleCount = ref(0);
+onMounted(() => {
+  judgeLoad();
   getRemoteTimeout();
   getIdleTimeout();
   activeTime = new Date().getTime();


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [ ] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [ ] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [ ] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ ] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

一个小fix，这个简单的处理方案Yixun哥看看能不能接受。

我看社区里也有不少人提过这个问题，就是刷新远控页面时候因为资源还没有释放完，会黑屏闪退，显示当前设备暂不可用。
我就是判断一下页面是否为刷新，刷新就延时1.5s再建立连接，安卓这边1.5s肯定ok了，我这边已经用了一段时间了，用户感知上还是比较丝滑的，ios我没设备不知道1.5s够不够

![image](https://github.com/SonicCloudOrg/sonic-client-web/assets/74577492/17b56bcd-9e14-4eeb-b803-bb771a10b82c)
https://sonic-cloud.wiki/d/902/2
https://sonic-cloud.wiki/d/2506-iosandroid/6

