### PR TITLE
feat:Android与iOS端长列表的场景下，实现“滚动到指定元素”可见的能力，前端UI实现

### DIFF
--- a/src/components/StepShow.vue
+++ b/src/components/StepShow.vue
@@ -69,6 +69,16 @@ const getAssertTextOpe = (s) => {
   }
 };
 
+const getScrollToDire = (direction) => {
+  switch (direction) {
+    case 'up':
+      return '向上';
+    case 'down':
+      return '向下';
+    default:
+      return '未知滚动方向类型';
+  }
+}
 const getEleResult = (s) => {
   const ss = s.toUpperCase();
   if (ss.indexOf('POCO') !== -1) {
@@ -640,7 +650,7 @@ const getNotes = (text, type) => {
   </span>
   <span v-if="step.stepType === 'scrollToEle'">
     <el-tag size="small"
-      >{{step.text}}滚动到{{ getEleResult(step.stepType) }}控件元素</el-tag
+      >{{getScrollToDire(step.text)}}滚动到{{ getEleResult(step.stepType) }}控件元素</el-tag
     >
     <el-tag type="info" size="small" style="margin-left: 10px; margin-right: 10px">{{ step.elements[0]['eleName'] }}</el-tag>
     最多尝试{{step.content}}次

--- a/src/components/StepShow.vue
+++ b/src/components/StepShow.vue
@@ -638,6 +638,13 @@ const getNotes = (text, type) => {
     >
     最大 {{ step.content }} 层
   </span>
+  <span v-if="step.stepType === 'scrollToEle'">
+    <el-tag size="small"
+      >{{step.text}}滚动到{{ getEleResult(step.stepType) }}控件元素</el-tag
+    >
+    <el-tag type="info" size="small" style="margin-left: 10px; margin-right: 10px">{{ step.elements[0]['eleName'] }}</el-tag>
+    最多尝试{{step.content}}次
+  </span>
   <span>
     <el-tag
       v-if="step.conditionType !== 3 && step.conditionType !== 0"

--- a/src/components/StepUpdate.vue
+++ b/src/components/StepUpdate.vue
@@ -329,7 +329,8 @@ const getStepInfo = (id) => {
         step.value.stepType === 'setDefaultFindWebViewElementInterval' ||
         step.value.stepType === 'longPress' ||
         step.value.stepType === 'checkImage' ||
-        step.value.stepType === 'setSnapshotMaxDepth'
+        step.value.stepType === 'setSnapshotMaxDepth' ||
+        step.value.stepType === 'scrollToEle'
       ) {
         step.value.content = parseInt(step.value.content);
       }
@@ -539,6 +540,10 @@ const androidOptions = ref([
           {
             value: 'swipe2',
             label: '拖拽控件元素',
+          },
+          {
+            value: 'scrollToEle',
+            label: '滚动到控件元素',
           },
           {
             value: 'longPress',
@@ -941,6 +946,10 @@ const iOSOptions = ref([
           {
             value: 'swipe2',
             label: '拖拽控件元素',
+          },
+          {
+            value: 'scrollToEle',
+            label: '滚动到控件元素',
           },
           {
             value: 'longPress',
@@ -1979,6 +1988,49 @@ onMounted(() => {
           type="normal"
           :step="step"
         />
+      </div>
+
+      <div v-if="step.stepType === 'scrollToEle'">
+        <el-alert
+          show-icon
+          style="margin-bottom: 10px"
+          close-text="Get!"
+          type="info"
+          title="TIPS: 长列表的场景下，可通过该方法连续滚动，尝试让目标元素可见"
+        />
+        <element-select
+          label="目标控件"
+          place="请选择控件元素"
+          :index="0"
+          :project-id="projectId"
+          type="normal"
+          :step="step"
+        />
+        <el-form-item
+          label="滚动方向"
+          prop="content"
+          :rules="{
+            required: true,
+            message: '滚动方向不能为空',
+            trigger: 'change',
+          }"
+        >
+          <el-select v-model="step.text">
+            <el-option label="向下" value="向下"></el-option>
+            <el-option label="向上" value="向上"></el-option>
+          </el-select>
+        </el-form-item>
+        <el-form-item
+          label="滚动次数"
+          prop="text"
+          :rules="{
+            required: true,
+            message: '滚动次数不能为空',
+            trigger: 'change',
+          }"
+        >
+          <el-input-number v-model="step.content" :min="1" :step="1"></el-input-number>
+        </el-form-item>
       </div>
 
       <div v-if="step.stepType === 'setSnapshotMaxDepth'">

--- a/src/components/StepUpdate.vue
+++ b/src/components/StepUpdate.vue
@@ -2016,8 +2016,8 @@ onMounted(() => {
           }"
         >
           <el-select v-model="step.text">
-            <el-option label="向下" value="向下"></el-option>
-            <el-option label="向上" value="向上"></el-option>
+            <el-option label="向下" value="down"></el-option>
+            <el-option label="向上" value="up"></el-option>
           </el-select>
         </el-form-item>
         <el-form-item

--- a/src/components/StepUpdate.vue
+++ b/src/components/StepUpdate.vue
@@ -2021,7 +2021,7 @@ onMounted(() => {
           </el-select>
         </el-form-item>
         <el-form-item
-          label="滚动次数"
+          label="最多滚动"
           prop="text"
           :rules="{
             required: true,
@@ -2030,6 +2030,7 @@ onMounted(() => {
           }"
         >
           <el-input-number v-model="step.content" :min="1" :step="1"></el-input-number>
+          <span style="margin-left: 10px">次</span>
         </el-form-item>
       </div>
 


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

[Agent端pr](https://github.com/SonicCloudOrg/sonic-agent/pull/357) 配套前端UI实现。

