### PR TITLE
feat:iOS端视图树dump页面，增加chassChain定位方式的录入

### DIFF
--- a/src/locales/lang/zh_CN.js
+++ b/src/locales/lang/zh_CN.js
@@ -1057,6 +1057,7 @@ const IOSRemote = {
     '点击开始抓包后，Wifi设置手动代理，连接右上角对应的ip与端口，即可开启抓包',
   filterClassOrName: '输入class或name进行过滤',
   predicate: 'Predicate推荐',
+  classChain: 'classChain推荐',
   noRecommend: '暂无推荐语法',
 };
 export default {

--- a/src/views/RemoteEmulator/IOSRemote.vue
+++ b/src/views/RemoteEmulator/IOSRemote.vue
@@ -413,6 +413,18 @@ const findBestNS = (elementDetail) => {
   result.push(r);
   return result;
 };
+const findBestClassChain = (elementDetail) => {
+  const result = [];
+  if (elementDetail.name) {
+    result.push(`**/${elementDetail.type}[\`name == \"${elementDetail.name}\"\`]`);
+    result.push(`**/${elementDetail.type}[\`name CONTAINS \"${elementDetail.name}\"\`]`);
+  }
+  if (elementDetail.label) {
+    result.push(`**/${elementDetail.type}[\`label == \"${elementDetail.label}\"\`]`);
+    result.push(`**/${elementDetail.type}[\`label CONTAINS \"${elementDetail.label}\"\`]`);
+  }
+  return result;
+};
 const findBestXpath = (elementDetail) => {
   const result = [];
   if (elementDetail.name) {
@@ -2793,6 +2805,40 @@ const checkAlive = () => {
                                         "
                                         @click="
                                           toAddElement('nsPredicate', scope.row)
+                                        "
+                                      >
+                                        <Pointer />
+                                      </el-icon>
+                                    </template>
+                                  </el-table-column>
+                                </el-table>
+                              </el-form-item>
+                              <el-form-item :label="$t('IOSRemote.classChain')">
+                                <el-table
+                                  stripe
+                                  :empty-text="$t('IOSRemote.noRecommend')"
+                                  border
+                                  :data="findBestClassChain(elementDetail)"
+                                  :show-header="false"
+                                >
+                                  <el-table-column>
+                                    <template #default="scope">
+                                      <span
+                                        style="cursor: pointer"
+                                        @click="copy(scope.row)"
+                                        >{{ scope.row }}</span
+                                      >
+                                      <el-icon
+                                        v-if="project && project['id']"
+                                        color="green"
+                                        size="16"
+                                        style="
+                                          vertical-align: middle;
+                                          margin-left: 10px;
+                                          cursor: pointer;
+                                        "
+                                        @click="
+                                          toAddElement('classChain', scope.row)
                                         "
                                       >
                                         <Pointer />


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

ios平台的元素定位方式中，xpath定位效率比较差，Appium官方更推荐的方案是classChain和predicate表达式这两种

[How to Find Elements in iOS (Not) By XPath](https://appiumpro.com/editions/8-how-to-find-elements-in-ios-not-by-xpath)

目前只默认提供了xpath和predicate表达式的自动生成，本次mr补充上classChain方式

