### PR TITLE
【feat】优化公共步骤页面的打开速度

### DIFF
--- a/src/views/PublicStep.vue
+++ b/src/views/PublicStep.vue
@@ -80,6 +80,25 @@ const deletePublicStep = (id) => {
       }
     });
 };
+const curShowPublicStep = ref({
+  id: null,
+  projectId: route.params.projectId,
+  platform: 0,
+  name: '',
+  steps: [],
+});
+/**
+ * 点击列表上的某个公共元素信息之后，再拉取单个公共步骤的子步骤信息
+ * @param id 公共步骤id
+ */
+const getPublicStepInfo = (id) => {
+  curShowPublicStep.value.steps = [];
+  axios.get('/controller/publicSteps', { params: { id } }).then((resp) => {
+    if (resp.code === 2000) {
+      curShowPublicStep.value = resp.data;
+    }
+  });
+};
 onMounted(() => {
   getPublicStepList();
 });
@@ -124,9 +143,9 @@ onMounted(() => {
     >
       <template #default="scope">
         <el-popover placement="left" :width="700" trigger="click">
-          <child-step-list-view :steps="scope.row.steps" />
+          <child-step-list-view :steps="curShowPublicStep.steps" />
           <template #reference>
-            <el-button size="mini">{{
+            <el-button size="mini" @click="getPublicStepInfo(scope.row.id)">{{
               $t('publicStepTS.viewSteps')
             }}</el-button>
           </template>


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

业务实际使用的过程中，发现公共步骤Page打开速度很慢，查看Ngnix日志经常会达到8秒以上

```
GET /server/api/controller/publicSteps/list?projectId=3&page=1&pageSize=15 HTTP/1.1" 200 "6.958" "74862"
GET /server/api/controller/publicSteps/list?projectId=3&page=2&pageSize=15 HTTP/1.1" 200 "9.158" "95470"
GET /server/api/controller/publicSteps/list?projectId=3&page=2&pageSize=15 HTTP/1.1" 200 "9.123" "95470"
```

排查耗时主要在拉取公共步骤列表的接口时，会遍历查询每个公共步骤的所有子步骤信息，并填充返回。

实际上子步骤的信息在列表展示时并不需要，这里优化为点击每个公共步骤的详情按钮时，再单独拉取子步骤信息，整体页面打开速度会明显提升。
