### PR TITLE
feat: 测试步骤可以从不同层级分组之间自由拖拽

### DIFF
--- a/src/components/StepDraggable.vue
+++ b/src/components/StepDraggable.vue
@@ -37,6 +37,7 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  parentId: Number, // 用于分组拖拽时，更新step数据的parentId
 });
 const emit = defineEmits([
   'flush',
@@ -64,27 +65,51 @@ const switchStep = (id, e) => {
     });
 };
 const sortStep = (e) => {
-  if (props.isEdit && props.steps[e.moved.newIndex].parentId === 0) {
+  if (e.removed !== undefined) {
     return;
   }
   let startId = null;
   let endId = null;
   let direction = '';
-  if (e.moved.newIndex > e.moved.oldIndex) {
-    direction = 'down';
-    endId = props.steps[e.moved.newIndex].sort;
-    startId = props.steps[e.moved.newIndex - 1].sort;
+  let newIndex = null;
+  let thisSort = null;
+  let newParentId = null;
+  let caseId = null;
+  if (e.added !== undefined) {
+    // eslint-disable-next-line vue/no-mutating-props
+    props.steps[e.added.newIndex].parentId = props.parentId; // 更新parentId
+    caseId = props.steps[e.added.newIndex].caseId;
+    newParentId = props.parentId;
+    newIndex = e.added.newIndex;
+    thisSort = props.steps[e.added.newIndex].sort;
+    // 此场景中下面3个参数不重要，为了兼容后端参数要求随便填的，它们会由后端进行处理
+    direction = 'added';
+    startId = 1;
+    endId = 2;
   } else {
-    direction = 'up';
-    startId = props.steps[e.moved.newIndex].sort;
-    endId = props.steps[e.moved.newIndex + 1].sort;
+    caseId = props.steps[e.moved.newIndex].caseId;
+    if (props.isEdit && props.steps[e.moved.newIndex].parentId === 0) {
+      return;
+    }
+    if (e.moved.newIndex > e.moved.oldIndex) {
+      direction = 'down';
+      endId = props.steps[e.moved.newIndex].sort;
+      startId = props.steps[e.moved.newIndex - 1].sort;
+    } else {
+      direction = 'up';
+      startId = props.steps[e.moved.newIndex].sort;
+      endId = props.steps[e.moved.newIndex + 1].sort;
+    }
   }
   axios
     .put('/controller/steps/stepSort', {
-      caseId: props.steps[e.moved.newIndex].caseId,
+      caseId,
       direction,
       startId,
       endId,
+      newParentId,
+      newIndex,
+      thisSort,
     })
     .then((resp) => {
       if (resp.code === 2000) {
@@ -117,8 +142,8 @@ const remove = (e) => {
  * 拷贝步骤的方法
  * @param {*} id  步骤id
  * @param {*} toLast 是否复制到最后一行
- */ 
- const copyStep = (id, toLast) => {
+ */
+const copyStep = (id, toLast) => {
   emit('copyStep', id, toLast);
 };
 /**
@@ -126,17 +151,19 @@ const remove = (e) => {
  * @param {*} id         点选的位置
  * @param {*} toNext     true添加到下一行，false添加到上一行
  */
- const addStepTotarget = (id, toNext) => {
+const addStepTotarget = (id, toNext) => {
   emit('addStepTotarget', id, toNext);
 };
 </script>
 
 <template>
   <el-scrollbar style="height: 100%">
-    <el-timeline v-if="steps.length > 0" class="stepsTimeline">
+    <el-timeline class="stepsTimeline">
+      <!-- 设置group，这样同名的group之间就可以互相拖拽 -->
       <VueDraggableNext
         tag="div"
         :list="steps"
+        group="case-step"
         handle=".handle"
         animation="200"
         force-fallback="true"
@@ -241,6 +268,7 @@ const remove = (e) => {
             </template>
             <step-draggable
               :steps="s['childSteps']"
+              :parent-id="s['id']"
               @setParent="setParent"
               @addStep="addStep"
               @flush="emit('flush')"
@@ -279,7 +307,6 @@ const remove = (e) => {
                   <Edit />
                 </el-icon>
               </el-button>
-              
               <!--添加操作的按钮-->
               <el-popconfirm
                 v-if="s.parentId === 0 && !isEdit"
@@ -300,7 +327,7 @@ const remove = (e) => {
                     </el-icon>
                   </el-button>
                 </template>
-            </el-popconfirm>
+              </el-popconfirm>
 
               <!--复制操作的按钮-->
               <el-popconfirm
@@ -362,7 +389,10 @@ const remove = (e) => {
         </el-timeline-item>
       </VueDraggableNext>
     </el-timeline>
-    <el-empty v-else :description="$t('steps.empty')"></el-empty>
+    <el-empty
+      v-if="steps.length === 0"
+      :description="$t('steps.empty')"
+    ></el-empty>
   </el-scrollbar>
 </template>
 

--- a/src/components/StepDraggable.vue
+++ b/src/components/StepDraggable.vue
@@ -72,7 +72,7 @@ const sortStep = (e) => {
   let endId = null;
   let direction = '';
   let newIndex = null;
-  let thisSort = null;
+  let stepsId = null;
   let newParentId = null;
   let caseId = null;
   if (e.added !== undefined) {
@@ -81,7 +81,7 @@ const sortStep = (e) => {
     caseId = props.steps[e.added.newIndex].caseId;
     newParentId = props.parentId;
     newIndex = e.added.newIndex;
-    thisSort = props.steps[e.added.newIndex].sort;
+    stepsId = props.steps[e.added.newIndex].id;
     // 此场景中下面3个参数不重要，为了兼容后端参数要求随便填的，它们会由后端进行处理
     direction = 'added';
     startId = 1;
@@ -109,7 +109,7 @@ const sortStep = (e) => {
       endId,
       newParentId,
       newIndex,
-      thisSort,
+      stepsId,
     })
     .then((resp) => {
       if (resp.code === 2000) {

--- a/src/components/StepList.vue
+++ b/src/components/StepList.vue
@@ -43,26 +43,26 @@ const addStep = () => {
 const addStepTotarget = (id, toNext) => {
   dialogVisible.value = true;
   addToTargetStepId.value = id;
-  addToTargetStepNext.value = toNext
+  addToTargetStepNext.value = toNext;
 };
 const flush = () => {
   if (addToTargetStepId.value > 0) {
     // 需要将新增的步骤挪动到目标行的上面或下面
     axios
-    .get('/controller/steps/stepSortTarget', {
-      params: {
-        targetStepId: addToTargetStepId.value,
-        addToTargetNext: addToTargetStepNext.value,
-      },
-    })
-    .then((resp) => {
-      if (resp.code === 2000) {
-        dialogVisible.value = false;
-        addToTargetStepNext.value = false;
-        addToTargetStepId.value = 0;
-        getStepsList();
-      }
-    });
+      .get('/controller/steps/stepSortTarget', {
+        params: {
+          targetStepId: addToTargetStepId.value,
+          addToTargetNext: addToTargetStepNext.value,
+        },
+      })
+      .then((resp) => {
+        if (resp.code === 2000) {
+          dialogVisible.value = false;
+          addToTargetStepNext.value = false;
+          addToTargetStepId.value = 0;
+          getStepsList();
+        }
+      });
   } else {
     dialogVisible.value = false;
     getStepsList();
@@ -149,7 +149,7 @@ const copyStep = (id, toLast) => {
     .get('/controller/steps/copy/steps', {
       params: {
         id,
-        toLast
+        toLast,
       },
     })
     .then((resp) => {
@@ -233,8 +233,10 @@ onMounted(() => {
       }}</el-button>
     </el-button-group>
   </div>
+  <!-- 第一层所有步骤的parentId都是0 -->
   <step-draggable
     :steps="steps"
+    :parent-id="0"
     @setParent="setParent"
     @addStep="addStep"
     @flush="flush"


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description

https://github.com/SonicCloudOrg/sonic-client-web/assets/44832826/e78167d8-92e0-41e7-ba0d-c61758e93cf5

- 效果：写if、else-if……的时候，可以复用外部或者其他分组中的步骤，通过拖拽的方式在不同分组中移动（原本是只能同组内改变排序，判断分支只能新增步骤，不能拖拽其他分组的步骤进来），提高编写脚本的效率

- 后端：https://github.com/SonicCloudOrg/sonic-server/pull/459