### PR TITLE
feat: 在获取元素页面中快捷测试元素定位是否可以定位并点击

### DIFF
--- a/src/components/ElementUpdate.vue
+++ b/src/components/ElementUpdate.vue
@@ -9,8 +9,9 @@ const props = defineProps({
   projectId: Number,
   elementId: Number,
   elementObj: Object,
+  isRemotePage: Boolean,
 });
-const emit = defineEmits(['flush']);
+const emit = defineEmits(['flush', 'checkLocation']);
 const element = ref({
   id: null,
   eleName: '',
@@ -75,6 +76,9 @@ const saveElement = () => {
       });
     }
   });
+};
+const testElement = () => {
+  emit('checkLocation', element.value);
 };
 const moduleList = ref([]);
 const getModuleList = () => {
@@ -216,6 +220,13 @@ onMounted(() => {
       </el-select>
     </el-form-item>
     <div style="text-align: center">
+      <el-button
+        v-if="isRemotePage"
+        size="small"
+        type="warning"
+        @click="testElement"
+        >{{ '测试' }}</el-button
+      >
       <el-button size="small" type="primary" @click="saveElement">{{
         $t('form.save')
       }}</el-button>

--- a/src/components/ElementUpdate.vue
+++ b/src/components/ElementUpdate.vue
@@ -10,6 +10,7 @@ const props = defineProps({
   elementId: Number,
   elementObj: Object,
   isRemotePage: Boolean,
+  checkLoading: Boolean,
 });
 const emit = defineEmits(['flush', 'checkLocation']);
 const element = ref({
@@ -224,8 +225,10 @@ onMounted(() => {
         v-if="isRemotePage"
         size="small"
         type="warning"
+        :loading="checkLoading"
+        :disabled="checkLoading"
         @click="testElement"
-        >{{ '测试' }}</el-button
+        >{{ $t('form.test') }}</el-button
       >
       <el-button size="small" type="primary" @click="saveElement">{{
         $t('form.save')

--- a/src/locales/lang/en_US.js
+++ b/src/locales/lang/en_US.js
@@ -374,6 +374,7 @@ const form = {
   inputNewPasswordAgain: 'Please input your new password again',
   confirm: 'Confirm',
   cancel: 'Cancel',
+  test: 'Test',
 };
 // 弹窗相关
 const dialog = {

--- a/src/locales/lang/ja_JP.js
+++ b/src/locales/lang/ja_JP.js
@@ -317,6 +317,7 @@ const form = {
   inputNewPasswordAgain: '新パスワードを再度入力してください',
   confirm: '確定',
   cancel: 'キャンセル',
+  test: 'テスト',
 };
 // 弹窗相关
 const dialog = {

--- a/src/locales/lang/zh_CN.js
+++ b/src/locales/lang/zh_CN.js
@@ -370,6 +370,7 @@ const form = {
   inputNewPasswordAgain: '请再次输入新密码',
   confirm: '确定',
   cancel: '取消',
+  test: '测试',
 };
 // 弹窗相关
 const dialog = {

--- a/src/locales/lang/zh_TW.js
+++ b/src/locales/lang/zh_TW.js
@@ -315,6 +315,7 @@ const form = {
   inputNewPasswordAgain: '請再次輸入新密碼',
   confirm: '確定',
   cancel: '取消',
+  test: '測試',
 };
 // 彈出型視窗相關
 const dialog = {

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -69,6 +69,7 @@ import {
   Service,
   VideoCamera,
   Postcard,
+  Aim,
 } from '@element-plus/icons';
 
 import { useI18n } from 'vue-i18n';
@@ -148,6 +149,7 @@ const activeTab = ref('main');
 const activeTab2 = ref('step');
 const stepLog = ref([]);
 const debugLoading = ref(false);
+const checkElementLoading = ref(false);
 const dialogElement = ref(false);
 const dialogImgElement = ref(false);
 const imgElementUrl = ref(null);
@@ -860,6 +862,7 @@ const websocketOnmessage = (message) => {
     }
     case 'status': {
       debugLoading.value = false;
+      checkElementLoading.value = false;
       ElMessage.info({
         message: $t('androidRemoteTS.runOver'),
       });
@@ -1364,6 +1367,7 @@ const runStep = () => {
   );
 };
 const checkLocation = (data) => {
+  checkElementLoading.value = true;
   websocket.send(
     JSON.stringify({
       type: 'debug',
@@ -1830,6 +1834,7 @@ const checkAlive = () => {
       :element-id="0"
       :element-obj="element"
       :is-remote-page="true"
+      :check-loading="checkElementLoading"
       @flush="dialogElement = false"
       @check-location="checkLocation"
     />
@@ -3706,6 +3711,23 @@ const checkAlive = () => {
                                   >{{ elementDetail['resource-id'] }}</span
                                 >
                                 <el-icon
+                                  color="green"
+                                  size="16"
+                                  style="
+                                    vertical-align: middle;
+                                    margin-left: 10px;
+                                    cursor: pointer;
+                                  "
+                                  @click="
+                                    checkLocation({
+                                      eleType: 'id',
+                                      eleValue: elementDetail['resource-id'],
+                                    })
+                                  "
+                                >
+                                  <Aim />
+                                </el-icon>
+                                <el-icon
                                   v-if="project && project['id']"
                                   color="green"
                                   size="16"
@@ -3744,6 +3766,23 @@ const checkAlive = () => {
                                         >{{ scope.row }}</span
                                       >
                                       <el-icon
+                                        color="green"
+                                        size="16"
+                                        style="
+                                          vertical-align: middle;
+                                          margin-left: 10px;
+                                          cursor: pointer;
+                                        "
+                                        @click="
+                                          checkLocation({
+                                            eleType: 'xpath',
+                                            eleValue: scope.row,
+                                          })
+                                        "
+                                      >
+                                        <Aim />
+                                      </el-icon>
+                                      <el-icon
                                         v-if="project && project['id']"
                                         color="green"
                                         size="16"
@@ -3769,6 +3808,23 @@ const checkAlive = () => {
                                 <span @click="copy(elementDetail['xpath'])">{{
                                   elementDetail['xpath']
                                 }}</span>
+                                <el-icon
+                                  color="green"
+                                  size="16"
+                                  style="
+                                    vertical-align: middle;
+                                    margin-left: 10px;
+                                    cursor: pointer;
+                                  "
+                                  @click="
+                                    checkLocation({
+                                      eleType: 'xpath',
+                                      eleValue: elementDetail['xpath'],
+                                    })
+                                  "
+                                >
+                                  <Aim />
+                                </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
                                   color="green"
@@ -3804,6 +3860,23 @@ const checkAlive = () => {
                                   @click="copy(elementDetail['content-desc'])"
                                   >{{ elementDetail['content-desc'] }}</span
                                 >
+                                <el-icon
+                                  color="green"
+                                  size="16"
+                                  style="
+                                    vertical-align: middle;
+                                    margin-left: 10px;
+                                    cursor: pointer;
+                                  "
+                                  @click="
+                                    checkLocation({
+                                      eleType: 'accessibilityId',
+                                      eleValue: elementDetail['content-desc'],
+                                    })
+                                  "
+                                >
+                                  <Aim />
+                                </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
                                   color="green"
@@ -3850,6 +3923,28 @@ const checkAlive = () => {
                                     )
                                   }}</span
                                 >
+                                <el-icon
+                                  color="green"
+                                  size="16"
+                                  style="
+                                    vertical-align: middle;
+                                    margin-left: 10px;
+                                    cursor: pointer;
+                                  "
+                                  @click="
+                                    checkLocation({
+                                      eleType: 'point',
+                                      eleValue: computedCenter(
+                                        elementDetail['x'],
+                                        elementDetail['y'],
+                                        elementDetail['width'],
+                                        elementDetail['height']
+                                      ),
+                                    })
+                                  "
+                                >
+                                  <Aim />
+                                </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
                                   color="green"

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -69,7 +69,7 @@ import {
   Service,
   VideoCamera,
   Postcard,
-  Aim,
+  Location,
 } from '@element-plus/icons';
 
 import { useI18n } from 'vue-i18n';
@@ -3725,7 +3725,7 @@ const checkAlive = () => {
                                     })
                                   "
                                 >
-                                  <Aim />
+                                  <Location />
                                 </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
@@ -3780,7 +3780,7 @@ const checkAlive = () => {
                                           })
                                         "
                                       >
-                                        <Aim />
+                                        <Location />
                                       </el-icon>
                                       <el-icon
                                         v-if="project && project['id']"
@@ -3823,7 +3823,7 @@ const checkAlive = () => {
                                     })
                                   "
                                 >
-                                  <Aim />
+                                  <Location />
                                 </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
@@ -3875,7 +3875,7 @@ const checkAlive = () => {
                                     })
                                   "
                                 >
-                                  <Aim />
+                                  <Location />
                                 </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
@@ -3943,7 +3943,7 @@ const checkAlive = () => {
                                     })
                                   "
                                 >
-                                  <Aim />
+                                  <Location />
                                 </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"

--- a/src/views/RemoteEmulator/AndroidRemote.vue
+++ b/src/views/RemoteEmulator/AndroidRemote.vue
@@ -557,30 +557,23 @@ const stopLogcat = () => {
   );
 };
 const saveLogcat = () => {
-  if (logcatOutPut && Array.isArray(logcatOutPut.value)) {
-
+  if (logcatOutPut.value && Array.isArray(logcatOutPut.value)) {
     const logContent = logcatOutPut.value.join('\n');
-    
     const blob = new Blob([logContent], { type: 'text/plain;charset=utf-8' });
-    
     const url = URL.createObjectURL(blob);
-
     const now = new Date();
     const formattedDate = now.toISOString().replace(/:/g, '-').split('.')[0];
-    const modelName = device.value['model']; 
+    const modelName = device.value.model;
     const fileName = `${modelName}_${formattedDate}.log`;
-    
     const a = document.createElement('a');
     a.href = url;
-    
     a.download = fileName;
     document.body.appendChild(a);
     a.click();
-    
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
   } else {
-    console.error("logcatOutPut or logcatOutPut.value not expect");
+    console.error('logcatOutPut or logcatOutPut.value not expect');
   }
 };
 
@@ -1370,6 +1363,17 @@ const runStep = () => {
     })
   );
 };
+const checkLocation = (data) => {
+  websocket.send(
+    JSON.stringify({
+      type: 'debug',
+      detail: 'checkLocation',
+      element: data.eleValue,
+      eleType: data.eleType,
+      pwd: device.value.password,
+    })
+  );
+};
 const stopStep = () => {
   debugLoading.value = false;
   websocket.send(
@@ -1825,7 +1829,9 @@ const checkAlive = () => {
       :project-id="project['id']"
       :element-id="0"
       :element-obj="element"
+      :is-remote-page="true"
       @flush="dialogElement = false"
+      @check-location="checkLocation"
     />
   </el-dialog>
   <remote-page-header

--- a/src/views/RemoteEmulator/IOSRemote.vue
+++ b/src/views/RemoteEmulator/IOSRemote.vue
@@ -36,7 +36,7 @@ import ElementUpdate from '@/components/ElementUpdate.vue';
 import Pageable from '@/components/Pageable.vue';
 import defaultLogo from '@/assets/logo.png';
 import {
-  Aim,
+  Location,
   Place,
   FullScreen,
   Download,
@@ -2800,7 +2800,7 @@ const checkAlive = () => {
                                     })
                                   "
                                 >
-                                  <Aim />
+                                  <Location />
                                 </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
@@ -2851,7 +2851,7 @@ const checkAlive = () => {
                                           })
                                         "
                                       >
-                                        <Aim />
+                                        <Location />
                                       </el-icon>
                                       <el-icon
                                         v-if="project && project['id']"
@@ -2902,7 +2902,7 @@ const checkAlive = () => {
                                           })
                                         "
                                       >
-                                        <Aim />
+                                        <Location />
                                       </el-icon>
                                       <el-icon
                                         v-if="project && project['id']"
@@ -2957,7 +2957,7 @@ const checkAlive = () => {
                                           })
                                         "
                                       >
-                                        <Aim />
+                                        <Location />
                                       </el-icon>
                                       <el-icon
                                         v-if="project && project['id']"
@@ -3000,7 +3000,7 @@ const checkAlive = () => {
                                     })
                                   "
                                 >
-                                  <Aim />
+                                  <Location />
                                 </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
@@ -3088,7 +3088,7 @@ const checkAlive = () => {
                                     })
                                   "
                                 >
-                                  <Aim />
+                                  <Location />
                                 </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"

--- a/src/views/RemoteEmulator/IOSRemote.vue
+++ b/src/views/RemoteEmulator/IOSRemote.vue
@@ -130,6 +130,7 @@ const activeTab = ref('main');
 const activeTab2 = ref('step');
 const stepLog = ref([]);
 const debugLoading = ref(false);
+const checkElementLoading = ref(false);
 const dialogElement = ref(false);
 const dialogImgElement = ref(false);
 const imgElementUrl = ref(null);
@@ -815,6 +816,7 @@ const websocketOnmessage = (message) => {
     }
     case 'status': {
       debugLoading.value = false;
+      checkElementLoading.value = false;
       ElMessage.info({
         message: $t('androidRemoteTS.runOver'),
       });
@@ -1083,6 +1085,18 @@ const runStep = () => {
       type: 'debug',
       detail: 'runStep',
       caseId: testCase.value.id,
+    })
+  );
+};
+const checkLocation = (data) => {
+  checkElementLoading.value = true;
+  websocket.send(
+    JSON.stringify({
+      type: 'debug',
+      detail: 'checkLocation',
+      element: data.eleValue,
+      eleType: data.eleType,
+      pwd: device.value.password,
     })
   );
 };
@@ -1360,7 +1374,10 @@ const checkAlive = () => {
       :project-id="project['id']"
       :element-id="0"
       :element-obj="element"
+      :is-remote-page="true"
+      :check-loading="checkElementLoading"
       @flush="dialogElement = false"
+      @check-location="checkLocation"
     />
   </el-dialog>
   <remote-page-header
@@ -2769,6 +2786,23 @@ const checkAlive = () => {
                                   elementDetail['name']
                                 }}</span>
                                 <el-icon
+                                  color="green"
+                                  size="16"
+                                  style="
+                                    vertical-align: middle;
+                                    margin-left: 10px;
+                                    cursor: pointer;
+                                  "
+                                  @click="
+                                    checkLocation({
+                                      eleType: 'accessibilityId',
+                                      eleValue: elementDetail['name'],
+                                    })
+                                  "
+                                >
+                                  <Aim />
+                                </el-icon>
+                                <el-icon
                                   v-if="project && project['id']"
                                   color="green"
                                   size="16"
@@ -2803,6 +2837,23 @@ const checkAlive = () => {
                                         >{{ scope.row }}</span
                                       >
                                       <el-icon
+                                        color="green"
+                                        size="16"
+                                        style="
+                                          vertical-align: middle;
+                                          margin-left: 10px;
+                                          cursor: pointer;
+                                        "
+                                        @click="
+                                          checkLocation({
+                                            eleType: 'nsPredicate',
+                                            eleValue: scope.row,
+                                          })
+                                        "
+                                      >
+                                        <Aim />
+                                      </el-icon>
+                                      <el-icon
                                         v-if="project && project['id']"
                                         color="green"
                                         size="16"
@@ -2836,6 +2887,23 @@ const checkAlive = () => {
                                         @click="copy(scope.row)"
                                         >{{ scope.row }}</span
                                       >
+                                      <el-icon
+                                        color="green"
+                                        size="16"
+                                        style="
+                                          vertical-align: middle;
+                                          margin-left: 10px;
+                                          cursor: pointer;
+                                        "
+                                        @click="
+                                          checkLocation({
+                                            eleType: 'classChain',
+                                            eleValue: scope.row,
+                                          })
+                                        "
+                                      >
+                                        <Aim />
+                                      </el-icon>
                                       <el-icon
                                         v-if="project && project['id']"
                                         color="green"
@@ -2875,6 +2943,23 @@ const checkAlive = () => {
                                         >{{ scope.row }}</span
                                       >
                                       <el-icon
+                                        color="green"
+                                        size="16"
+                                        style="
+                                          vertical-align: middle;
+                                          margin-left: 10px;
+                                          cursor: pointer;
+                                        "
+                                        @click="
+                                          checkLocation({
+                                            eleType: 'xpath',
+                                            eleValue: scope.row,
+                                          })
+                                        "
+                                      >
+                                        <Aim />
+                                      </el-icon>
+                                      <el-icon
                                         v-if="project && project['id']"
                                         color="green"
                                         size="16"
@@ -2900,6 +2985,23 @@ const checkAlive = () => {
                                 <span @click="copy(elementDetail['xpath'])">{{
                                   elementDetail['xpath']
                                 }}</span>
+                                <el-icon
+                                  color="green"
+                                  size="16"
+                                  style="
+                                    vertical-align: middle;
+                                    margin-left: 10px;
+                                    cursor: pointer;
+                                  "
+                                  @click="
+                                    checkLocation({
+                                      eleType: 'xpath',
+                                      eleValue: elementDetail['xpath'],
+                                    })
+                                  "
+                                >
+                                  <Aim />
+                                </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
                                   color="green"
@@ -2966,6 +3068,28 @@ const checkAlive = () => {
                                     )
                                   }}</span
                                 >
+                                <el-icon
+                                  color="green"
+                                  size="16"
+                                  style="
+                                    vertical-align: middle;
+                                    margin-left: 10px;
+                                    cursor: pointer;
+                                  "
+                                  @click="
+                                    checkLocation({
+                                      eleType: 'point',
+                                      eleValue: computedCenter(
+                                        elementDetail['x'],
+                                        elementDetail['y'],
+                                        elementDetail['width'],
+                                        elementDetail['height']
+                                      ),
+                                    })
+                                  "
+                                >
+                                  <Aim />
+                                </el-icon>
                                 <el-icon
                                   v-if="project && project['id']"
                                   color="green"


### PR DESCRIPTION
> Whether this PR is eventually merged or not, Sonic will thank you very much for your contribution. 
> 
> 无论此PR最终是否合并，Sonic组织都非常感谢您的贡献。

### Checklist

- [x] The title starts with fix, fea, or doc. | 标题为fix、feat或doc开头。
- [x] I have checked that there are no duplicate pull requests with this request. | 我已检查没有与此请求重复的拉取请求。
- [x] I have considered and confirmed that this submission is valuable to others. | 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] I accept that this submission may not be used. | 我接受此提交可能不会被使用。

### Description
1. ios、安卓原生控件页面，右侧推荐定位增加一个快捷测试按钮，同时在增加元素弹窗中也增加了一个测试按钮（有的场景可能需要自己手写元素定位）
2. ！！！poco的我没有接入sdk的app，所以不知道长啥样的，没有去动。
3. 因为agent执行点击也是使用原有的方法操作，所以当前会话中测试定位后，在UI自动化的log日志中会有记录。


https://github.com/user-attachments/assets/ab6d6ff8-4de2-422a-950e-51c093df705b


